### PR TITLE
Add SPLiT-seq pipeline notebook

### DIFF
--- a/splitseq_kallisto_pipeline.ipynb
+++ b/splitseq_kallisto_pipeline.ipynb
@@ -1,0 +1,152 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# SPLiT-seq processing pipeline using splitcode and kallisto-bus",
+        "This notebook provides an end-to-end example of processing SPLiT-seq data using [splitcode](https://splitcode.readthedocs.io/en/latest/tutorials_splitseq.html) for barcode extraction and [kallisto | bustools](https://www.kallistobus.tools/) for alignment and quantification."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Setup",
+        "Install `splitcode` and `kb-python` (which contains `kallisto` and `bustools`)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "!pip install -q kb-python splitcode"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Download example data",
+        "Replace the link below with your own SPLiT-seq FASTQ files. The example data from [Pachter lab](https://github.com/pachterlab/LSRRSRLFKOTWMWMP_2024) was uploaded to Zenodo."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "!wget https://zenodo.org/records/14146317/files/lr-kallisto_example.tar.gz",
+        "!tar -xvf lr-kallisto_example.tar.gz"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "The archive contains example FASTQ files and configuration files for `splitcode`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "!ls lr-kallisto_example"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Build transcriptome index",
+        "`kb ref` is used to build the transcriptome index for kallisto. Here we fetch a pre-built mouse index and gene mapping."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "!kb ref -i mouse_k63.idx -g mouse.t2g -f1 mouse.fa --download=mouse"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Extract barcodes with splitcode",
+        "Use the provided configuration file describing the SPLiT-seq layout. This step produces read files with corrected barcodes and UMIs."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "!splitcode -c lr-kallisto_example/config-correct.txt --nFastqs 2 --select 0 --gzip -o cDNA.fastq.gz _cDNA.fastq _barcode.fastq -t 2"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "!splitcode -c lr-kallisto_example/config-correct.txt --nFastqs 2 --select 0 --gzip -o umi.fastq.gz _umi.fastq _barcode.fastq -t 2"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "!splitcode -c lr-kallisto_example/config.mergeRT -o barcode.fastq barcode.fastq.gz -t 2"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Pseudoalignment and counting",
+        "We use `kb count` with the `--long` flag because this dataset contains long reads. Replace `-k 63` with the k-mer length of your index."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "!kb count -k 63 --long -i mouse_k63.idx -g mouse.t2g -o output -x '2,0,24:1,0,10:0,0,0' cDNA.fastq.gz umi.fastq.gz barcode.fastq"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "After running, the resulting matrix and metadata are located in the `output` folder."
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "pygments_lexer": "ipython3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a Colab notebook `splitseq_kallisto_pipeline.ipynb` demonstrating SPLiT-seq processing using `splitcode` and `kallisto | bustools`

## Testing
- `python -m json.tool splitseq_kallisto_pipeline.ipynb`

------
https://chatgpt.com/codex/tasks/task_e_6874e21b22c4832ca2ba0343fd8fe460