### PR TITLE
Fix STAR removal steps

### DIFF
--- a/EasySci_pipeline.sh
+++ b/EasySci_pipeline.sh
@@ -61,7 +61,10 @@ echo
 ## STAR alignment
 echo "Start alignment using STAR..."
 mkdir -p $output_folder/STAR_alignment
-STAR --genomeDir $index --genomeLoad Remove
+star_tmp="/dev/shm/STARtmp-$(basename "$index")"
+if [ -d "$star_tmp" ]; then
+    STAR --genomeDir $index --genomeLoad Remove
+fi
 
 for sample in $(cat $sample_ID)
 do 
@@ -69,7 +72,10 @@ echo "Aligning $sample..."
 STAR --runThreadN $cores --outSAMstrandField intronMotif --genomeDir $index --readFilesCommand zcat --readFilesIn $output_folder/trimmed_fastqs/$sample*R1*gz $output_folder/trimmed_fastqs/$sample*R2*gz --outFileNamePrefix $output_folder/STAR_alignment/$sample --genomeLoad LoadAndKeep
 done
 
-STAR --genomeDir $index --genomeLoad Remove
+star_tmp="/dev/shm/STARtmp-$(basename "$index")"
+if [ -d "$star_tmp" ]; then
+    STAR --genomeDir $index --genomeLoad Remove
+fi
 echo "Done aligning"
 echo
 
@@ -188,7 +194,10 @@ echo
 ## STAR alignment
 echo "Start alignment using STAR..."
 mkdir -p $output_folder/STAR_alignment
-STAR --genomeDir $index --genomeLoad Remove
+star_tmp="/dev/shm/STARtmp-$(basename "$index")"
+if [ -d "$star_tmp" ]; then
+    STAR --genomeDir $index --genomeLoad Remove
+fi
 
 for sample in $(cat $sample_ID)
 do 
@@ -196,7 +205,10 @@ echo "Aligning $sample..."
 STAR --runThreadN $cores --outSAMstrandField intronMotif --genomeDir $index --readFilesCommand zcat --readFilesIn $output_folder/trimmed_fastqs/$sample*R2*gz --outFileNamePrefix $output_folder/STAR_alignment/$sample --genomeLoad LoadAndKeep
 done
 
-STAR --genomeDir $index --genomeLoad Remove
+star_tmp="/dev/shm/STARtmp-$(basename "$index")"
+if [ -d "$star_tmp" ]; then
+    STAR --genomeDir $index --genomeLoad Remove
+fi
 echo "Done aligning"
 echo
 

--- a/test1
+++ b/test1
@@ -28,7 +28,11 @@ if sequencing_type == "paired-end":
     # STAR alignment
     print("Start alignment using STAR...")
     os.makedirs(os.path.join(output_folder, 'STAR_alignment'), exist_ok=True)
-    subprocess.run(['STAR', '--genomeDir', index, '--genomeLoad', 'Remove'])
+    # Clear any STAR genome that might still be loaded from previous runs.
+    # STAR exits with an error if no genome is loaded, so check before calling.
+    star_tmp = f"/dev/shm/STARtmp-{os.path.basename(index.rstrip('/'))}"
+    if os.path.exists(star_tmp):
+        subprocess.run(['STAR', '--genomeDir', index, '--genomeLoad', 'Remove'])
 
     for sample in samples:
         print(f"Aligning {sample}...")
@@ -40,7 +44,10 @@ if sequencing_type == "paired-end":
             r2 = r2_files[0]
             subprocess.run(['STAR', '--runThreadN', str(cores), '--outSAMstrandField', 'intronMotif', '--genomeDir', index, '--readFilesCommand', 'zcat', '--readFilesIn', os.path.join(trimmed_dir, r1), os.path.join(trimmed_dir, r2), '--outFileNamePrefix', os.path.join(output_folder, 'STAR_alignment/', sample + '_'), '--genomeLoad', 'LoadAndKeep'])
 
-    subprocess.run(['STAR', '--genomeDir', index, '--genomeLoad', 'Remove'])
+    # Clear previous STAR genome only if it is present in shared memory.
+    star_tmp = f"/dev/shm/STARtmp-{os.path.basename(index.rstrip('/'))}"
+    if os.path.exists(star_tmp):
+        subprocess.run(['STAR', '--genomeDir', index, '--genomeLoad', 'Remove'])
     print("Done aligning")
     print()
 
@@ -183,7 +190,10 @@ else:  # single-end
     # STAR alignment
     print("Start alignment using STAR...")
     os.makedirs(os.path.join(output_folder, 'STAR_alignment'), exist_ok=True)
-    subprocess.run(['STAR', '--genomeDir', index, '--genomeLoad', 'Remove'])
+    # Clear any STAR genome left from a previous run before alignment.
+    star_tmp = f"/dev/shm/STARtmp-{os.path.basename(index.rstrip('/'))}"
+    if os.path.exists(star_tmp):
+        subprocess.run(['STAR', '--genomeDir', index, '--genomeLoad', 'Remove'])
 
     for sample in samples:
         print(f"Aligning {sample}...")
@@ -193,7 +203,10 @@ else:  # single-end
             r2 = r2_files[0]
             subprocess.run(['STAR', '--runThreadN', str(cores), '--outSAMstrandField', 'intronMotif', '--genomeDir', index, '--readFilesCommand', 'zcat', '--readFilesIn', os.path.join(trimmed_dir, r2), '--outFileNamePrefix', os.path.join(output_folder, 'STAR_alignment/', sample + '_'), '--genomeLoad', 'LoadAndKeep'])
 
-    subprocess.run(['STAR', '--genomeDir', index, '--genomeLoad', 'Remove'])
+    # Remove STAR genome from shared memory when alignment is done.
+    star_tmp = f"/dev/shm/STARtmp-{os.path.basename(index.rstrip('/'))}"
+    if os.path.exists(star_tmp):
+        subprocess.run(['STAR', '--genomeDir', index, '--genomeLoad', 'Remove'])
     print("Done aligning")
     print()
 


### PR DESCRIPTION
## Summary
- avoid STAR fatal error in the Python demo script by checking for the shared-memory index before running `--genomeLoad Remove`
- apply the same safety check in `EasySci_pipeline.sh`

## Testing
- `python -m py_compile test1`


------
https://chatgpt.com/codex/tasks/task_e_6879262ad11c832c8fe6af340eb1479b